### PR TITLE
Added dependency on jpacman-framework test code.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,12 +162,6 @@
 						</plugin>
 
 						<plugin>
-							<groupId>org.codehaus.mojo</groupId>
-							<artifactId>findbugs-maven-plugin</artifactId>
-							<version>2.3.2</version>
-						</plugin>
-
-						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-surefire-report-plugin</artifactId>
 							<version>2.17</version>


### PR DESCRIPTION
So that also test classes and test stubs (residing in the JPacman-Framework `src/test` folder) can also be used in the templates `src/test` folder.

As discussed in https://github.com/SERG-Delft/jpacman-framework/pull/26
