### PR TITLE
Made DirectionTest North-specific

### DIFF
--- a/src/test/java/nl/tudelft/jpacman/board/DirectionTest.java
+++ b/src/test/java/nl/tudelft/jpacman/board/DirectionTest.java
@@ -5,7 +5,8 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 /**
- * A very simple test class to have a starting point where to put tests.
+ * A very simple (and not particularly useful)
+ * test class to have a starting point where to put tests.
  * 
  * @author Arie van Deursen
  *
@@ -13,11 +14,12 @@ import org.junit.Test;
 public class DirectionTest {
 
 	/**
-	 * Do we get the correct horizontal delta when moving north?
+	 * Do we get the correct delta when moving north?
 	 */
 	@Test
-	public void directionTest() {
-		assertEquals(0, Direction.NORTH.getDeltaX());
+	public void testNorth() {
+		Direction north = Direction.valueOf("NORTH");
+		assertEquals(-1, north.getDeltaY());
 	}
 
 }


### PR DESCRIPTION
This way the test is a little easier to understand and extend,
and easier to use for experimenting with coverage.

Test coverage of an Enum such as Direction in
EclEmma is a bit tricky due to bytecode generated for enums. See

http://stackoverflow.com/questions/4512358/emma-coverage-on-enum-types