### PR TITLE
Devhub reports

### DIFF
--- a/pmd-rules.xml
+++ b/pmd-rules.xml
@@ -5,7 +5,7 @@
          xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
 
     <description>
-        Custom PMD ruleset for MonkeyRush test code.
+        Custom rules for checking JUnit test quality.
     </description>
 
     <rule ref="rulesets/java/basic.xml"/>

--- a/pmd-rules.xml
+++ b/pmd-rules.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         name="Custom ruleset"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+
+    <description>
+        Custom PMD ruleset for MonkeyRush test code.
+    </description>
+
+    <rule ref="rulesets/java/basic.xml"/>
+    <rule ref="rulesets/java/unusedcode.xml"/>
+    <rule ref="rulesets/java/imports.xml"/>
+    <rule ref="rulesets/java/strings.xml"/>
+    <rule ref="rulesets/java/codesize.xml"/>
+    <rule ref="rulesets/java/braces.xml"/>
+    <rule ref="rulesets/java/clone.xml"/>
+    <rule ref="rulesets/java/empty.xml"/>
+    <rule ref="rulesets/java/junit.xml">
+        <exclude name="JUnitAssertionsShouldIncludeMessage"/>
+    </rule>
+</ruleset>

--- a/pmd-rules.xml
+++ b/pmd-rules.xml
@@ -18,5 +18,11 @@
     <rule ref="rulesets/java/empty.xml"/>
     <rule ref="rulesets/java/junit.xml">
         <exclude name="JUnitAssertionsShouldIncludeMessage"/>
+	<exclude name="JUnitTestContainsTooManyAsserts" />
+    </rule>
+    <rule ref="rulesets/java/junit.xml/JUnitTestContainsTooManyAsserts">
+        <properties>
+            <property name="maximumAsserts" value="5" />
+        </properties>
     </rule>
 </ruleset>

--- a/pom.xml
+++ b/pom.xml
@@ -166,12 +166,6 @@
 				</configuration>
 			</plugin>
 
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>3.0.0</version>
-			</plugin>
-
 			<plugin> <!-- JUnit report -->
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
@@ -182,6 +176,26 @@
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>cobertura-maven-plugin</artifactId>
 				<version>2.7</version>
+			</plugin>
+
+			<!-- PMD configuration for JUnit tests -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-pmd-plugin</artifactId>
+				<version>3.4</version>
+				<configuration>
+					<skipEmptyReport>false</skipEmptyReport>
+					<includeTests>true</includeTests>
+					<rulesets>
+						<ruleset>pmd-rules.xml</ruleset>
+					</rulesets>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>findbugs-maven-plugin</artifactId>
+				<version>3.0.0</version>
 			</plugin>
 		</plugins>
 	</reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,9 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<targetJdk>1.7</targetJdk>
+		<checkstyle.plugin.version>2.15</checkstyle.plugin.version>
+		<pmd.plugin.version>3.4</pmd.plugin.version>
+		<findbugs.version>3.0.0</findbugs.version>
 	</properties>
 
     <repositories>
@@ -119,6 +122,45 @@
 					</execution>
 				</executions>
 			</plugin>
+
+			<!-- The checkstyle, findbugs and PMD plugins have configurations,
+				for the checkstyle:checkstyle and pmd:pmd to work properly,
+				the plugins should also be specified under the build section.
+				See: https://github.com/sevntu-checkstyle/checkstyle-samples/blob/master/maven-project/pom.xml
+			-->
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>${checkstyle.plugin.version}</version>
+				<configuration>
+					<configLocation>${basedir}/checkstyle.xml</configLocation>
+					<includeTestSourceDirectory>true</includeTestSourceDirectory>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-pmd-plugin</artifactId>
+				<version>${pmd.plugin.version}</version>
+				<configuration>
+					<skipEmptyReport>false</skipEmptyReport>
+					<includeTests>true</includeTests>
+					<rulesets>
+						<ruleset>pmd-rules.xml</ruleset>
+					</rulesets>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>findbugs-maven-plugin</artifactId>
+				<version>${findbugs.version}</version>
+				<configuration>
+					<xmlOutput>true</xmlOutput>
+					<includeTests>true</includeTests>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
@@ -159,10 +201,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>2.15</version>
+				<version>${checkstyle.plugin.version}</version>
 				<configuration>
 					<configLocation>${basedir}/checkstyle.xml</configLocation>
-					<includeTestSourceDirectory> true </includeTestSourceDirectory>
+					<includeTestSourceDirectory>true</includeTestSourceDirectory>
 				</configuration>
 			</plugin>
 
@@ -182,7 +224,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
-				<version>3.4</version>
+				<version>${pmd.plugin.version}</version>
 				<configuration>
 					<skipEmptyReport>false</skipEmptyReport>
 					<includeTests>true</includeTests>
@@ -195,7 +237,11 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>${findbugs.version}</version>
+                                <configuration>
+                                        <xmlOutput>true</xmlOutput>
+                                        <includeTests>true</includeTests>
+                                </configuration>
 			</plugin>
 		</plugins>
 	</reporting>


### PR DESCRIPTION
As far as I can see now ([example](https://github.com/sevntu-checkstyle/checkstyle-samples/blob/master/maven-project/pom.xml), [Stackoverflow question](http://stackoverflow.com/questions/30467166/mvn-checkstylecheckstyle-uses-wrong-configuration-when-using-reporting)), plugins should be defined twice in order to work both separately and using reporting with custom configurations.

This PR builds on top of #12 and changes the following things:
* PMD reporting is added (see #12)
* PMD reporting is configured with a custom XML that allows us to set some parameters.
* Plugins with configuration (Checkstyle, Findbugs, PMD) are added to the build phase as well so Devhub (and devs) can run them separately.
* Test package is included for findbugs, as this defaults to `false`, but is the package the students actually do the most work in
* XML report is enabled for findbugs.