### PR TITLE
Enable check style warning suppression

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -11,7 +11,9 @@
 <module name="Checker">
   <property name="severity" value="warning"/>
   <module name="TreeWalker">
+    <module name="SuppressWarningsHolder" />
     <property name="tabWidth" value="4"/>
+    <module name="FileContentsHolder"/>
     <module name="JavadocMethod">
       <property name="scope" value="package"/>
       <property name="suppressLoadErrors" value="true"/>
@@ -117,4 +119,7 @@
     <property name="message" value="Line has trailing spaces."/>
     <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
   </module>
+  <module name="SuppressionCommentFilter"/>
+  <module name="SuppressWithNearbyCommentFilter"/>
+  <module name="SuppressWarningsFilter" />
 </module>


### PR DESCRIPTION
Allow the use of the `@SuppressWarnings` annotations in Checkstyle.

See
http://stackoverflow.com/questions/4023185/how-to-disable-a-particular-checkstyle-rule-for-a-particular-line-of-code/22556386#22556386