### PR TITLE
Added PMD rule to warn for tests that catch exceptions

### DIFF
--- a/pmd-rules.xml
+++ b/pmd-rules.xml
@@ -18,11 +18,54 @@
     <rule ref="rulesets/java/empty.xml"/>
     <rule ref="rulesets/java/junit.xml">
         <exclude name="JUnitAssertionsShouldIncludeMessage"/>
-	<exclude name="JUnitTestContainsTooManyAsserts" />
+	      <exclude name="JUnitTestContainsTooManyAsserts" />
     </rule>
     <rule ref="rulesets/java/junit.xml/JUnitTestContainsTooManyAsserts">
         <properties>
             <property name="maximumAsserts" value="5" />
         </properties>
+    </rule>
+    <rule name="UseExpectedThrowsInsteadOfCatchStatement"
+          language="java"
+          since="5.5"
+          message="Use @Test(expected = Exception.class) or the ExpectedException JUnit rule instead of catching exceptions within test methods."
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/junit.html#UseExpectedThrowsInsteadOfCatchStatement">
+        <description>When asserting that an exception is thrown, use @Test(expected = Exception.class) or the ExpectedException JUnit rule instead of catching exceptions within test methods.</description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
+//CatchStatement
+[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[typeof(@Image, 'junit.framework.TestCase','TestCase')] or //MarkerAnnotation/Name[typeof(@Image, 'org.junit.Test', 'Test')]]]
+]]>
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
+public class MyTestCase {
+
+	@Test
+	public void badTestCase() {
+		try {
+			MayThrow.execute();
+		}
+		catch (Exception e) {
+			return;
+		}
+		fail();
+	}
+
+
+	@Test(expected = Exception.class)
+	public void goodTestCase() throws Exception {
+		MayThrow.execute();
+	}
+
+}
+]]>
+        </example>
     </rule>
 </ruleset>


### PR DESCRIPTION
This PR tries to address the students that come up with creative ways to check if an exception is thrown. In JUnit it is prefered to use the [`expected` attribute](http://junit.sourceforge.net/javadoc/org/junit/Test.html#expected()) of the `@Test` annotation, or the [`ExpectedException`](http://junit.org/javadoc/latest/org/junit/rules/ExpectedException.html) TestRule implementation. As there has never been any response to [my thread](https://sourceforge.net/p/pmd/discussion/188192/thread/e7e3e20c/) on the PMD forum, I suggest to add the rule to the projects local rule set.

Some implementations this PMD rule will address:
```java
 public void testFoo() {
     try {
         doSomething();
         fail("should have thrown an exception");
     } catch (Exception e) {
     }
}

 public void testFoo2() {
     try {
         doSomething(); 
     } catch (Exception e) {
         return;
     }
     fail("should have thrown an exception");
}

 public void testFoo3() {
     try {
         doSomething(); 
     } catch (Exception e) {
         assertTrue(true);
     }
}
```

I think, in fact, any Catch statement in a Test method makes no sense, as you one want a single execution path through your test method. Therefore I came up with the following XPath expression:

```
//CatchStatement
[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[typeof(@Image, 'junit.framework.TestCase','TestCase')] or //MarkerAnnotation/Name[typeof(@Image, 'org.junit.Test', 'Test')]]]
```
