### PR TITLE
Updated pom.xml to include the latest version of cucumber

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 		<junit.version>4.12</junit.version>
 		<mockito.version>2.0.47-beta</mockito.version>
 		<hamcrest.version>1.3</hamcrest.version>
-		<cucumber.version>1.2.2</cucumber.version>
+		<cucumber.version>1.2.4</cucumber.version>
 
 		<surefire.plugin.version>2.19.1</surefire.plugin.version>
 		<javadoc.plugin.version>2.10.3</javadoc.plugin.version>


### PR DESCRIPTION
Version 1.2.2 of cucumber contains a bug where cucumber cannot find cucumber-java-1.2.2.jar when the path consists of a whitespace (%20).
Version 1.2.4 fixes this bug.