### PR TITLE
Add checkstyle rules for uniform indentation

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -93,6 +93,14 @@
       <property name="severity" value="ignore"/>
       <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
     </module>
+    <module name="Indentation">
+      <property name="basicOffset" value="4" />
+      <property name="braceAdjustment" value="0" />
+      <property name="caseIndent" value="4" />
+      <property name="throwsIndent" value="8" />
+      <property name="arrayInitIndent" value="4" />
+      <property name="lineWrappingIndentation" value="8" />
+    </module>
     <module name="TodoComment">
       <property name="severity" value="ignore"/>
       <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
@@ -102,6 +110,9 @@
     <module name="MethodLength">
       <property name="max" value="30"/>
     </module>
+  </module>
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
   </module>
   <module name="NewlineAtEndOfFile">
     <property name="severity" value="ignore"/>


### PR DESCRIPTION
See https://github.com/SERG-Delft/jpacman-framework/pull/113.

> This PR introduces checkstyle rules to make the type of indentation consistent.
> 
> The rules disallow the use of tabs (as done in both [Google Java Style](https://github.com/checkstyle/checkstyle/blob/de50d3465849b83d25910590e1f5f39a25fe6e2c/config/checkstyle_checks.xml#L128) as [Checkstyle Style](https://github.com/checkstyle/checkstyle/blob/de50d3465849b83d25910590e1f5f39a25fe6e2c/config/checkstyle_checks.xml#L128)), because "Developers should not need to configure the tab width of their text editors in order to be able to read source code." (http://checkstyle.sourceforge.net/config_whitespace.html#FileTabCharacter). 
> 
> There are also rules for the number of spaces, based on [Checkstyle Style](https://github.com/checkstyle/checkstyle/blob/de50d3465849b83d25910590e1f5f39a25fe6e2c/config/checkstyle_checks.xml#L379) and the current state of the project.