### PR TITLE
Remove unnecessary access modifier from example test

### DIFF
--- a/src/test/java/nl/tudelft/jpacman/board/DirectionTest.java
+++ b/src/test/java/nl/tudelft/jpacman/board/DirectionTest.java
@@ -16,7 +16,7 @@ public class DirectionTest {
      * Do we get the correct delta when moving north?
      */
     @Test
-    public void testNorth() {
+    void testNorth() {
         Direction north = Direction.valueOf("NORTH");
         assertThat(north.getDeltaY()).isEqualTo(-1);
     }


### PR DESCRIPTION
Since jUnit 5 tests no longer need to be public, so we can remove the access modifier from the example test.